### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nuxtpr.yaml
+++ b/.github/workflows/nuxtpr.yaml
@@ -3,6 +3,8 @@
 # To get started with Nuxt see: https://nuxtjs.org/docs/get-started/installation
 #
 name: PR Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/djpc123/web/security/code-scanning/1](https://github.com/djpc123/web/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block to the workflow, restricting the GITHUB_TOKEN's permissions to the least privilege required. For a PR build/test workflow like this, `contents: read` is generally sufficient, as the build does not need write access to repository contents, issues, or pull requests. The `permissions` block can be added at the top level (so it applies to all jobs), ideally just under the `name` key and before the `on` section for clarity and standard format.

No new methods, imports, or external definitions are needed. The fix consists solely of inserting the following block at the correct place in `.github/workflows/nuxtpr.yaml`:

```yaml
permissions:
  contents: read
```

This will ensure the GITHUB_TOKEN used by actions is restricted to repository contents read-access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
